### PR TITLE
Export a yosys2digitaljs function to do the full conversion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1177,6 +1177,18 @@ export async function verilator_lint(filenames: string[], dirname?: string, opti
     }
 }
 
+export function yosys2digitaljs(obj: Yosys.Output, options: Options = {}): Digitaljs.TopModule {
+    const portmaps = order_ports(obj);
+    const out = yosys_to_digitaljs(obj, portmaps, options);
+    const toporder = topsort(module_deps(obj));
+    toporder.pop();
+    const toplevel = toporder.pop();
+    const output: Digitaljs.TopModule = { subcircuits: {}, ... out[toplevel] };
+    for (const x of toporder)
+        output.subcircuits[x] = out[x];
+    return output;
+}
+
 export async function process(filenames: string[], dirname?: string, options: Options = {}): Promise<Output> {
     const optimize_simp = options.optimize ? "; opt" : "; opt_clean";
     const optimize = options.optimize ? "; opt -full" : "; opt_clean";
@@ -1203,13 +1215,7 @@ export async function process(filenames: string[], dirname?: string, options: Op
         }
         obj = JSON.parse(fs.readFileSync(tmpjson, 'utf8'));
         await promisify(fs.unlink)(tmpjson);
-        const portmaps = order_ports(obj);
-        const out = yosys_to_digitaljs(obj, portmaps, options);
-        const toporder = topsort(module_deps(obj));
-        toporder.pop();
-        const toplevel = toporder.pop();
-        const output: Digitaljs.TopModule = { subcircuits: {}, ... out[toplevel] };
-        for (const x of toporder) output.subcircuits[x] = out[x];
+        const output = yosys2digitaljs(obj, options);
         const ret: Output = {
             output: output,
             yosys_output: obj,


### PR DESCRIPTION
From Yosys.Output to Digitaljs.TopModule.
This allow doing reusing most of the yosys2digitaljs functionality
without running the yosys command line tool.