### PR TITLE
Add 7 segment display device type.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1248,8 +1248,14 @@ export function io_ui(output: Digitaljs.Module) {
         }
         if (dev.type == 'Input')
             dev.type = dev.bits == 1 ? 'Button' : 'NumEntry';
-        if (dev.type == 'Output')
-            dev.type = dev.bits == 1 ? 'Lamp' : 'NumDisplay';
+        if (dev.type == 'Output') {
+            if (dev.bits == 1)
+                dev.type = 'Lamp';
+            else if (dev.bits == 8 && (dev.label == 'display7' || dev.label.startsWith('display7_')))
+                dev.type = 'Display7';
+            else
+                dev.type = 'NumDisplay';
+        }
     }
 }
 


### PR DESCRIPTION
`digitaljs` package already supports `Display7` device type. Now the lacking part is the `yosys2digitaljs` being unable to translate it from Yosys output. This pull request solves this issue.