### PR TITLE
add support for high impedance state 'bZ

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -175,9 +175,11 @@ namespace Digitaljs {
 
 namespace Yosys {
 
-    export type BitChar = '0' | '1' | 'x';
+    export const ConstChars = ["0", "1", "x", "z"] as const;
 
-    export type Bit = number | '0' | '1' | 'x';
+    export type BitChar = (typeof ConstChars)[number];
+
+    export type Bit = number | BitChar;
 
     export type BitVector = Bit[];
 
@@ -404,7 +406,7 @@ function yosys_to_digitaljs(data: Yosys.Output, portmaps: Portmaps, options: Con
 
 function yosys_to_digitaljs_mod(name: string, mod: Yosys.Module, portmaps: Portmaps, options: ConvertOptions = {}): Digitaljs.Module {
     function constbit(bit: Bit) {
-        return bit == '0' || bit == '1' || bit == 'x';
+        return (Yosys.ConstChars as readonly string[]).includes(bit.toString());
     }
     const nets = new HashMap<Net, NetInfo>();
     const netnames = new HashMap<Net, string[]>();

--- a/tests/z.sv
+++ b/tests/z.sv
@@ -1,0 +1,7 @@
+// high impedance state
+module sourceZ(
+  output out
+);
+  assign out = 1'bZ;
+
+endmodule


### PR DESCRIPTION
Currently, assignments with 'bZ lead to an error. DigitalJS treats z like x.